### PR TITLE
Support Contao 3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 	},
 	"require": {
 		"php":">=5.3",
-		"contao/core": ">=3.3,<3.5-dev",
+		"contao/core": ">=3.3,<3.6-dev",
 		"contao-community-alliance/composer-plugin": "~2.0",
 		"contao-community-alliance/event-dispatcher": "~1.0"
 	},


### PR DESCRIPTION
I've check the commit list for the changes between [Contao 3.4 and 3.5](https://github.com/contao/core/compare/3.4.5...3.5.0). As far as I see there's no public API changes. So we should be ready supporting Contao 3.5.