### PR TITLE
Fix handle event has details

### DIFF
--- a/src/ContaoCommunityAlliance/Contao/Bindings/Subscribers/CalendarSubscriber.php
+++ b/src/ContaoCommunityAlliance/Contao/Bindings/Subscribers/CalendarSubscriber.php
@@ -202,6 +202,8 @@ class CalendarSubscriber implements EventSubscriberInterface
 
                 $objTemplate->details .= $getContentElementEvent->getContentElementHtml();
             }
+
+            $objTemplate->hasDetails = true;
         }
 
         $objTemplate->addImage = false;

--- a/src/ContaoCommunityAlliance/Contao/Bindings/Subscribers/CalendarSubscriber.php
+++ b/src/ContaoCommunityAlliance/Contao/Bindings/Subscribers/CalendarSubscriber.php
@@ -8,6 +8,7 @@
  * @subpackage Subscribers
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     Sven Baumann <baumann.sv@gmail.com>
  * @copyright  The Contao Community Alliance
  * @license    LGPL.
  * @filesource


### PR DESCRIPTION
When i´m use template event_full, the details does't display out.
There is an if loop with $this-hasDetails.
The pull fix the problem.