### PR TITLE
Remove dependencies on legacy cca-extensions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "contao/core-bundle": "^4.4",
-    "contao-community-alliance/event-dispatcher": "^2.0",
     "symfony/event-dispatcher": "^3.0 || ^4.0"
   },
   "require-dev": {

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/events-contao-bindings
  *
- * (c) 2014-2018 The Contao Community Alliance
+ * (c) 2014-2019 The Contao Community Alliance
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,8 @@
  * @package    ContaoCommunityAlliance\Contao\Bindings
  * @subpackage System
  * @author     Sven Baumann <baumann.sv@gmail.com>
- * @copyright  2018 The Contao Community Alliance.
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2014-2019 The Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/events-contao-bindings/blob/master/LICENSE LGPL-3.0
  * @filesource
  */

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -26,7 +26,6 @@ use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use ContaoCommunityAlliance\Contao\Bindings\CcaEventsContaoBindingsBundle;
-use ContaoCommunityAlliance\Contao\EventDispatcher\CcaEventDispatcherBundle;
 
 /**
  * Plugin for the Contao Manager.
@@ -44,7 +43,6 @@ class Plugin implements BundlePluginInterface
                     [
                         ContaoCoreBundle::class,
                         ContaoManagerBundle::class,
-                        CcaEventDispatcherBundle::class
                     ]
                 )
                 ->setReplace(['events-contao-bindings'])


### PR DESCRIPTION
## Description

I removed the dependency on the package [`contao-community-alliance/dependency-container`](https://github.com/contao-community-alliance/dependency-container)
because it requires `pimple/pimple` in version 1.0. This conflicts with  [Deployer](https://github.com/deployphp/deployer), which requires Pimple in version 3.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
